### PR TITLE
[FEAT] 밴드 추천 업데이트 로직 수정

### DIFF
--- a/app/models/band.py
+++ b/app/models/band.py
@@ -1,5 +1,5 @@
 # app/models/band.py
-from sqlalchemy import Column, Integer, String, Text, TIMESTAMP
+from sqlalchemy import Column, Integer, String, Text, TIMESTAMP, Boolean
 from sqlalchemy.orm import relationship
 
 from app.core.db import Base
@@ -16,6 +16,7 @@ class Band(Base):
     main_music = Column(String(200), nullable=True)
     description = Column(Text, nullable=False)
     spotify_id = Column(String(100), nullable=True)
+    is_band = Column(Boolean, nullable=True, default=True)
     created_at = Column(TIMESTAMP(timezone=True), nullable=True)
     updated_at = Column(TIMESTAMP(timezone=True), nullable=True)
     deleted_at = Column(TIMESTAMP(timezone=True), nullable=True)


### PR DESCRIPTION
<!-- PR 이름은 '[컨벤션] 기능이름' 으로 통일해주세요.
 ex. [FEAT] searchPublicCourse -->

<!-- 라벨 라벨로 담당자를 표시
 ex. Hoyoung027 -->

## 🛰️ Issue Number
<!-- 해당 PR과 연결된 이슈를 닫아주세요. close #issue_number -->
close #20 


## 🪐 작업 내용
<!-- 해당 PR에서 작업한 내용을 적어주세요. -->
- 밴드 테이블에 밴드 이외의 가수들이 도입되었습니다.
- 이로 인해, 사용자 벡터 계산에는 사용자 선호 가수 및 밴드 전체의 임베딩 벡터를 포함하며 반환시에는 가수는 배제한 밴드 중에서 추천 결과가 반환되어야 합니다.
- 이러한 로직을 도입하여 새롭게 4번째 버전의 추천 알고리즘을 고안하였고, 이를 최종 밴드 업데이트 API에 연결하였습니다.



## 📚 Reference




### ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 포스트맨에서 결과값을 제대로 확인했나요?
- [ ] 리뷰어 설정을 지정했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?
